### PR TITLE
Make build on Mac work with a clean repo

### DIFF
--- a/org.leo.traceroute/build.xml
+++ b/org.leo.traceroute/build.xml
@@ -208,9 +208,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 		</exec>
 	</target>
 	<target name="package_mac">
+		<mkdir dir="${basedir}/product/mac" />
 		<taskdef name="jarbundler" classname="com.ultramixer.jarbundler.JarBundler" classpathref="ant.classpath" />
 		<jarbundler dir="product/mac" name="OpenVisualTraceroute" mainclass="org.leo.traceroute.Main"
-			jvmversion="${version}+" version="${version}" icon="build/mac/icon.icns"
+			jvmversion="1.4+" version="${version}" icon="build/mac/icon.icns"
 			bundleid="org.leo.traceroute.Main" signature="ovtr" build="0" antialiasedtext="true" antialiasedgraphics="true"
 		    stubfile="build/mac/universalJavaApplicationStub" useJavaXKey="true">
 			<jarfileset dir="product/universal">


### PR DESCRIPTION
For the `jvmversion` value a better fix would be to provide a real JVM version requirement, but this requires JarBundler 3.4.0 which [has not been released yet](https://github.com/UltraMixer/JarBundler/issues/22).